### PR TITLE
Update `EVP_MD_do_all` and `EVP_CIPHER_do_all`, add `EVP_PBE_validate_scrypt_params`

### DIFF
--- a/crypto/evp/scrypt.cc
+++ b/crypto/evp/scrypt.cc
@@ -142,6 +142,37 @@ static void scryptROMix(block_t *B, uint64_t r, uint64_t N, block_t *T,
 // |EVP_PBE_scrypt|.
 #define SCRYPT_MAX_MEM (1024 * 1024 * 65)
 
+int EVP_PBE_scrypt_validate_params(const char *password, size_t password_len,
+                                   const uint8_t *salt, size_t salt_len, uint64_t N, uint64_t r,
+                                   uint64_t p, size_t max_mem, uint8_t *out_key,
+                                   size_t key_len) {
+
+  if (r == 0 || p == 0 || p > SCRYPT_PR_MAX / r ||
+      // |N| must be a power of two.
+      N < 2 || (N & (N - 1)) ||
+      // We only support |N| <= 2^32 in |scryptROMix|.
+      N > UINT64_C(1) << 32 ||
+      // Check that |N| < 2^(128×r / 8).
+      (16 * r <= 63 && N >= UINT64_C(1) << (16 * r))) {
+    OPENSSL_PUT_ERROR(EVP, EVP_R_INVALID_PARAMETERS);
+    return 0;
+  }
+
+  // Determine the amount of memory needed. B, T, and V are |p|, 1, and |N|
+  // scrypt blocks, respectively. Each scrypt block is 2*|r| |block_t|s.
+  if (max_mem == 0) {
+    max_mem = SCRYPT_MAX_MEM;
+  }
+
+  size_t max_scrypt_blocks = max_mem / (2 * r * sizeof(block_t));
+  if (max_scrypt_blocks < p + 1 || max_scrypt_blocks - p - 1 < N) {
+    OPENSSL_PUT_ERROR(EVP, EVP_R_MEMORY_LIMIT_EXCEEDED);
+    return 0;
+  }
+
+  return 1;
+}
+
 int EVP_PBE_scrypt(const char *password, size_t password_len,
                    const uint8_t *salt, size_t salt_len, uint64_t N, uint64_t r,
                    uint64_t p, size_t max_mem, uint8_t *out_key,

--- a/crypto/evp/scrypt.cc
+++ b/crypto/evp/scrypt.cc
@@ -142,7 +142,7 @@ static void scryptROMix(block_t *B, uint64_t r, uint64_t N, block_t *T,
 // |EVP_PBE_scrypt|.
 #define SCRYPT_MAX_MEM (1024 * 1024 * 65)
 
-int EVP_PBE_scrypt_validate_params(const char *password, size_t password_len,
+int EVP_PBE_validate_scrypt_params(const char *password, size_t password_len,
                                    const uint8_t *salt, size_t salt_len, uint64_t N, uint64_t r,
                                    uint64_t p, size_t max_mem, uint8_t *out_key,
                                    size_t key_len) {

--- a/decrepit/evp/evp_do_all.cc
+++ b/decrepit/evp/evp_do_all.cc
@@ -19,36 +19,6 @@ void EVP_CIPHER_do_all_sorted(void (*callback)(const EVP_CIPHER *cipher,
                                                const char *name,
                                                const char *unused, void *arg),
                               void *arg) {
-  callback(EVP_aes_128_cbc(), "AES-128-CBC", NULL, arg);
-  callback(EVP_aes_128_cfb128(), "AES-128-CFB", NULL, arg);
-  callback(EVP_aes_192_cbc(), "AES-192-CBC", NULL, arg);
-  callback(EVP_aes_256_cbc(), "AES-256-CBC", NULL, arg);
-  callback(EVP_aes_256_cfb128(), "AES-256-CFB", NULL, arg);
-  callback(EVP_aes_128_ctr(), "AES-128-CTR", NULL, arg);
-  callback(EVP_aes_192_ctr(), "AES-192-CTR", NULL, arg);
-  callback(EVP_aes_256_ctr(), "AES-256-CTR", NULL, arg);
-  callback(EVP_aes_128_ecb(), "AES-128-ECB", NULL, arg);
-  callback(EVP_aes_192_ecb(), "AES-192-ECB", NULL, arg);
-  callback(EVP_aes_256_ecb(), "AES-256-ECB", NULL, arg);
-  callback(EVP_aes_128_ofb(), "AES-128-OFB", NULL, arg);
-  callback(EVP_aes_192_ofb(), "AES-192-OFB", NULL, arg);
-  callback(EVP_aes_256_ofb(), "AES-256-OFB", NULL, arg);
-  callback(EVP_aes_128_gcm(), "AES-128-GCM", NULL, arg);
-  callback(EVP_aes_192_gcm(), "AES-192-GCM", NULL, arg);
-  callback(EVP_aes_256_gcm(), "AES-256-GCM", NULL, arg);
-  callback(EVP_bf_cbc(), "BF-CBC", NULL, arg);
-  callback(EVP_bf_cfb(), "BF-CFB", NULL, arg);
-  callback(EVP_bf_ecb(), "BF-ECB", NULL, arg);
-  callback(EVP_des_cbc(), "DES-CBC", NULL, arg);
-  callback(EVP_des_ecb(), "DES-ECB", NULL, arg);
-  callback(EVP_des_ede(), "DES-EDE", NULL, arg);
-  callback(EVP_des_ede3(), "DES-EDE3", NULL, arg);
-  callback(EVP_des_ede_cbc(), "DES-EDE-CBC", NULL, arg);
-  callback(EVP_des_ede3_cbc(), "DES-EDE3-CBC", NULL, arg);
-  callback(EVP_rc2_cbc(), "RC2-CBC", NULL, arg);
-  callback(EVP_rc4(), "RC4", NULL, arg);
-
-  // OpenSSL returns everything twice, the second time in lower case.
   callback(EVP_aes_128_cbc(), "aes-128-cbc", NULL, arg);
   callback(EVP_aes_128_cfb128(), "aes-128-cfb", NULL, arg);
   callback(EVP_aes_192_cbc(), "aes-192-cbc", NULL, arg);
@@ -83,17 +53,6 @@ void EVP_MD_do_all_sorted(void (*callback)(const EVP_MD *cipher,
                                            const char *name, const char *unused,
                                            void *arg),
                           void *arg) {
-  callback(EVP_md4(), "MD4", NULL, arg);
-  callback(EVP_md5(), "MD5", NULL, arg);
-  callback(EVP_sha1(), "SHA1", NULL, arg);
-  callback(EVP_sha224(), "SHA224", NULL, arg);
-  callback(EVP_sha256(), "SHA256", NULL, arg);
-  callback(EVP_sha384(), "SHA384", NULL, arg);
-  callback(EVP_sha512(), "SHA512", NULL, arg);
-  callback(EVP_sha512_224(), "SHA512-224", NULL, arg);
-  callback(EVP_sha512_256(), "SHA512-256", NULL, arg);
-  callback(EVP_ripemd160(), "ripemd160", NULL, arg);
-
   callback(EVP_md4(), "md4", NULL, arg);
   callback(EVP_md5(), "md5", NULL, arg);
   callback(EVP_sha1(), "sha1", NULL, arg);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -488,8 +488,8 @@ OPENSSL_EXPORT int PKCS5_PBKDF2_HMAC_SHA1(const char *password,
                                           uint32_t iterations, size_t key_len,
                                           uint8_t *out_key);
 
-// Can be used to validate |N|, |r|, |p|, and max_mem parameters before calling EVP_PBE_scrypt.
-OPENSSL_EXPORT int EVP_PBE_scrypt_validate_params(const char *password, size_t password_len,
+// Can be used to validate |N|, |r|, |p|, and |max_mem| parameters before calling EVP_PBE_scrypt.
+OPENSSL_EXPORT int EVP_PBE_validate_scrypt_params(const char *password, size_t password_len,
                                   const uint8_t *salt, size_t salt_len,
                                   uint64_t N, uint64_t r, uint64_t p,
                                   size_t max_mem, uint8_t *out_key,

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -488,6 +488,13 @@ OPENSSL_EXPORT int PKCS5_PBKDF2_HMAC_SHA1(const char *password,
                                           uint32_t iterations, size_t key_len,
                                           uint8_t *out_key);
 
+// Can be used to validate |N|, |r|, |p|, and max_mem parameters before calling EVP_PBE_scrypt.
+OPENSSL_EXPORT int EVP_PBE_scrypt_validate_params(const char *password, size_t password_len,
+                                  const uint8_t *salt, size_t salt_len,
+                                  uint64_t N, uint64_t r, uint64_t p,
+                                  size_t max_mem, uint8_t *out_key,
+                                  size_t key_len);
+
 // EVP_PBE_scrypt expands |password| into a secret key of length |key_len| using
 // scrypt, as described in RFC 7914, and writes the result to |out_key|. It
 // returns one on success and zero on allocation failure, if the memory required


### PR DESCRIPTION
Changes `EVP_MD_do_all` and `EVP_CIPHER_do_all` to return names just in lowercase. There was a comment saying OpenSSL returns first in uppercase then in lowercase, but this seems to be out of date.

Also add `EVP_PBE_scrypt_validate_params` for validating params before calling `EVP_PBE_scrypt`.